### PR TITLE
feat(RedshiftOpMode): create RedshiftOpMode

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/readme.md
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/readme.md
@@ -1,3 +1,12 @@
+# Redshift Robotics
+You should have all of your OpModes extend `org.redshiftrobotics.RedshiftOpMode`.
+It provides many useful helper methods.
+
+## Methods:
+None yet.
+
+# FTC
+
 ## TeamCode Module
 
 Welcome!

--- a/TeamCode/src/main/java/org/redshiftrobotics/RedshiftOpMode.java
+++ b/TeamCode/src/main/java/org/redshiftrobotics/RedshiftOpMode.java
@@ -1,0 +1,7 @@
+package org.redshiftrobotics;
+
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+
+abstract public class RedshiftOpMode extends OpMode {
+
+}


### PR DESCRIPTION
This is an abstract class for all of our OpModes to impliment. It shouldn't ever include actual OpMode code, but can include helper code.

This is a prerequisite to #4, because I want the beacon recognition to be fairly self-contained, but it also requires access to things only avaliable within the OpMode.

