### PR TITLE
bug(.editorconfig): solve build errors on some systems

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 
 [*]
 
-indent_style = tabs
+indent_style = tab
 end_of_line = lf
 charset = utf-8
 insert_final_newline = true


### PR DESCRIPTION
Fix a bug in the editorconfig that creates build errors on some systems.